### PR TITLE
Change image arg to path arg

### DIFF
--- a/facial_alignment/align_faces.py
+++ b/facial_alignment/align_faces.py
@@ -8,21 +8,33 @@ import argparse
 import imutils
 import dlib
 import cv2
+import os
+import sys
 
 # construct the argument parser and parse the arguments
 ap = argparse.ArgumentParser()
 ap.add_argument("-p", "--shape-predictor", required=True,
     help="path to facial landmark predictor")
-ap.add_argument("-i", "--image", required=True, nargs='+',
-    help="path to input image")
+ap.add_argument("-i", "--folder", required=True, nargs='+',
+    help="full path to folder containing images")
 args = vars(ap.parse_args())
+
+extensions = ('.png','.jpg','.jpeg')
+
+try:
+    images = [file for file in os.listdir(args['folder']) if file.lower().endswith(extensions)]
+except:
+    sys.exit("Invalid folder name")
+
+if len(images) == 0:
+    sys.exit("No images found in folder")
 
 # initialize dlib's face detector (HOG-based) and then create
 # the facial landmark predictor and the face aligner
 detector = dlib.get_frontal_face_detector()
 predictor = dlib.shape_predictor(args["shape_predictor"])
 fa = FaceAligner(predictor, desiredFaceWidth=256)
-for image in args['image']:
+for image in images:
     print("processing:", image)
     # load the input image, resize it, and convert it to grayscale
     image = cv2.imread(image)

--- a/facial_alignment/align_faces.py
+++ b/facial_alignment/align_faces.py
@@ -1,5 +1,5 @@
 # USAGE
-# python align_faces.py --shape-predictor shape_predictor_68_face_landmarks.dat --image images/example_01.jpg
+# python align_faces.py --shape-predictor shape_predictor_68_face_landmarks.dat --folder /path/to/image/folder
 
 # import the necessary packages
 from imutils.face_utils import FaceAligner


### PR DESCRIPTION
Allow the user to specify path to folder containing images. Acceptable extensions are found in the tuple `extensions` . The extensions are case insensitive, so both PNG and png are acceptable.